### PR TITLE
Skip saving image without text

### DIFF
--- a/modules/filehandler.py
+++ b/modules/filehandler.py
@@ -63,8 +63,12 @@ class TargetFileHandler(FileSystemEventHandler):
         """指定された画像から文字部分を抽出します。"""
         try:
             output_path = TextExtractor(self.output_dir).extract_texts(file_path)
-            print(f'Text extraction succeeded: {output_path}')
-            logging.info(f'Text extraction succeeded: {output_path}')
+            if output_path:
+                print(f'Text extraction succeeded: {output_path}')
+                logging.info(f'Text extraction succeeded: {output_path}')
+            else:
+                print('No text detected. Skipped saving image.')
+                logging.info('No text detected. Skipped saving image.')
         except Exception as e:
             print('Text extraction failed: %s', e)
             logging.info('[!] Text extraction failed: %s', e)

--- a/modules/filehandler_communication.py
+++ b/modules/filehandler_communication.py
@@ -102,11 +102,17 @@ class TargetFileHandler(FileSystemEventHandler):
         try:
             output_path = TextExtractor(
                 self.output_dir).extract_texts(file_path)
-            print(f'Text extraction succeeded: {output_path}')
-            logging.info(f'Text extraction succeeded: {output_path}')
-            # 文字検出ログにもファイル処理の成功を記録
-            text_logger.info(
-                f'ファイル処理完了: {os.path.basename(file_path)} -> {os.path.basename(output_path)}')
+            if output_path:
+                print(f'Text extraction succeeded: {output_path}')
+                logging.info(f'Text extraction succeeded: {output_path}')
+                # 文字検出ログにもファイル処理の成功を記録
+                text_logger.info(
+                    f'ファイル処理完了: {os.path.basename(file_path)} -> {os.path.basename(output_path)}')
+            else:
+                print('No text detected. Skipped saving image.')
+                logging.info('No text detected. Skipped saving image.')
+                text_logger.info(
+                    f'ファイル処理スキップ: {os.path.basename(file_path)} - 文字なし')
         except Exception as e:
             print('Text extraction failed:', e)
             logging.info('[!] Text extraction failed: %s', e)

--- a/modules/text_extractor.py
+++ b/modules/text_extractor.py
@@ -91,8 +91,10 @@ class TextExtractor:
                 text_logger.info(f"検出テキスト: \n{detected_text.strip()}")
             else:
                 text_logger.info("テキスト認識できませんでした（ボックスのみ検出）")
+                return None
         else:
             text_logger.info(f"ファイル: {base_name} - 文字検出なし")
+            return None
 
         rgba = cv2.cvtColor(img, cv2.COLOR_BGR2BGRA)
         rgba[:, :, 3] = mask        # 出力先ディレクトリの処理


### PR DESCRIPTION
## Summary
- only save PNG when OCR detects real text
- warn in console/logs if no text is found

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f8f9fd4748327b57ef5b68bcd7b5b