### PR TITLE
Implement better OCR masking

### DIFF
--- a/modules/text_extractor.py
+++ b/modules/text_extractor.py
@@ -212,14 +212,14 @@ class TextExtractor:
                 if len(parts) >= 5:
                     char_count += 1
 
-        # マスク画像を作成
+        # マスク画像(文字領域)を作成
         mask = np.zeros((h, w), dtype=np.uint8)
 
         for b in boxes.splitlines():
             parts = b.split(' ')
             if len(parts) >= 5:
                 x1, y1, x2, y2 = map(int, parts[1:5])
-                # Tesseract's origin is at bottom-left
+                # Tesseract の座標系は左下が原点
                 mask[h - y2:h - y1, x1:x2] = 255
 
         # 文字検出結果をログに記録
@@ -244,8 +244,23 @@ class TextExtractor:
             logging.info(msg)
             return None
 
-        rgba = cv2.cvtColor(img, cv2.COLOR_BGR2BGRA)
-        rgba[:, :, 3] = mask        # 出力先ディレクトリの処理
+        # ----- 文字領域以外を白で塗りつぶす -----
+        filled = img.copy()
+        filled[mask == 0] = (255, 255, 255)
+
+        # ----- 二値化してテキストだけのマスクを作成 -----
+        gray_mask = cv2.cvtColor(filled, cv2.COLOR_BGR2GRAY)
+        _, binary = cv2.threshold(gray_mask, 0, 255,
+                                  cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+        text_mask = cv2.bitwise_not(binary)
+
+        # ----- マスクを用いて元画像から文字部分のみ抽出 -----
+        masked = cv2.bitwise_and(img, img, mask=text_mask)
+
+        # 透過PNG用にAlphaチャネルを設定
+        rgba = cv2.cvtColor(masked, cv2.COLOR_BGR2BGRA)
+        rgba[:, :, 3] = text_mask
+        # 出力先ディレクトリの処理
         if self.output_dir:
             # 出力先が指定されている場合はそこを使用
             out_dir = self.output_dir


### PR DESCRIPTION
## Summary
- refine mask building in `TextExtractor`
- fill non-text region with white
- create binary mask and apply transparency

## Testing
- `python3 -m py_compile modules/text_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_684f9f46723c8327abbf1ace25874418