### PR TITLE
Enable duplicate launch with flag

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,4 +13,5 @@
         "crop": false,
         "color_mode": "original",
         "color": "#000000"
+        , "single_instance_only": false
 }


### PR DESCRIPTION
## Summary
- add `--single_instance_only` option
- load boolean from config and arguments
- skip duplicate instance checks when the option is `true`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: pyenv missing pytest)*

------
https://chatgpt.com/codex/tasks/task_e_684fd52ae4a48327a4d47d6af4ca5aca