### PR TITLE
Fix color override

### DIFF
--- a/modules/text_extractor.py
+++ b/modules/text_extractor.py
@@ -71,9 +71,6 @@ class TextExtractor:
                 with open(config_path, 'r', encoding='utf-8') as f:
                     config = json.load(f)
                     self.ocr_engine = config.get('ocr_engine', "tesseract")
-                    self.crop = config.get('crop', self.crop)
-                    self.color_mode = config.get('color_mode', self.color_mode)
-                    self.mono_color = config.get('color', self.mono_color)
             except Exception as e:
                 text_logger.warning(f"設定ファイルの読み込みに失敗しました: {e}")
                 self.ocr_engine = "tesseract"


### PR DESCRIPTION
## Summary
- avoid overriding CLI options in `TextExtractor`

## Testing
- `python3 -m py_compile modules/text_extractor.py modules/filehandler.py modules/filehandler_communication.py main.py`
- `pip install --break-system-packages -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684fd6eeca788327b743628f92160ecc