### PR TITLE
Add GCP Vision support for saas OCR engine

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -137,7 +137,7 @@ text_cropping.exe --exclude_subdirectories --ip <IPアドレス> --port <ポー�
 
 * `pytesseract` (デフォルト): 基本的なOCR機能
 * `EasyOCR`: 高精度な多言語OCR (オプション)
-* `google`: Google Cloud Vision APIを使用 (オプション)
+* `saas`: Google Cloud Vision API を使用 (オプション)
 
 `config.json` または `--ocr_engine` オプションで OCR エンジンを設定できます:
 

--- a/modules/ocr_saas_gcp_visionai.py
+++ b/modules/ocr_saas_gcp_visionai.py
@@ -1,27 +1,67 @@
 import os
+from typing import Tuple
+import cv2
 from google.cloud import vision    # バージョン: 3.5.0
 
 
-def extract_text(image_file):
-    """Detects text in the file."""
-    os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "./gcp-signature.json"
+def extract_text(img) -> Tuple[str, str, int]:
+    """Detect text and bounding boxes using Google Cloud Vision API.
+
+    Parameters
+    ----------
+    img : numpy.ndarray
+        Image in BGR format.
+
+    Returns
+    -------
+    Tuple[str, str, int]
+        Detected full text, bounding boxes in Tesseract style and
+        character count.
+    """
+    os.environ.setdefault(
+        "GOOGLE_APPLICATION_CREDENTIALS", "./gcp-signature.json")
 
     client = vision.ImageAnnotatorClient()
 
-    with open(image_file, "rb") as image_file:
-        content = image_file.read()
+    success, buf = cv2.imencode('.png', img)
+    if not success:
+        raise RuntimeError("Failed to encode image for Vision API")
 
-    image = vision.Image(content=content)
+    image = vision.Image(content=buf.tobytes())
 
-    response = client.text_detection(image=image)
-    texts = response.text_annotations
-    result = texts[0].description if texts else None
+    response = client.document_text_detection(image=image)
 
     if response.error.message:
         raise Exception(
-            "{}\nFor more info on error messages, check: "
-            "https://cloud.google.com/apis/design/errors".format(
-                response.error.message)
-        )
+            f"{response.error.message}\nFor more info on error messages, check: "
+            "https://cloud.google.com/apis/design/errors")
 
-    print(f'Text: {result}')
+    annotation = response.full_text_annotation
+    result_text = annotation.text if annotation.text else ""
+
+    height, width = img.shape[:2]
+    boxes_list = []
+    char_count = 0
+
+    for page in annotation.pages:
+        for block in page.blocks:
+            for paragraph in block.paragraphs:
+                for word in paragraph.words:
+                    for symbol in word.symbols:
+                        ch = symbol.text
+                        if not ch or ch.isspace():
+                            continue
+                        char_count += 1
+                        vertices = symbol.bounding_box.vertices
+                        if len(vertices) >= 4:
+                            x1 = int(vertices[0].x)
+                            y1 = int(vertices[0].y)
+                            x2 = int(vertices[2].x)
+                            y2 = int(vertices[2].y)
+                            # Convert to Tesseract box format (origin bottom-left)
+                            boxes_list.append(
+                                f"{ch} {x1} {height - y2} {x2} {height - y1}")
+
+    boxes = "\n".join(boxes_list)
+
+    return result_text, boxes, char_count

--- a/modules/text_extractor.py
+++ b/modules/text_extractor.py
@@ -206,9 +206,14 @@ class TextExtractor:
             return None, None, 0
 
     def extract_texts_with_saas(self, img):
-        """SaaS型OCRを使用してテキストを抽出 (未実装)"""
-        text_logger.warning("SaaS OCR は未実装です")
-        return None, None, 0
+        """Use Google Cloud Vision API to extract texts."""
+        try:
+            from modules.ocr_saas_gcp_visionai import extract_text
+            detected_text, boxes, char_count = extract_text(img)
+            return detected_text, boxes, char_count
+        except Exception as e:
+            text_logger.error(f"SaaS OCR error: {e}")
+            return None, None, 0
 
     def extract_texts(self, file_path):
         # 日本語ファイル名対応のため、NumPyを使用して画像を読み込む

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytesseract
 pystray==0.19.4
 # 高精度OCR用追加ライブラリ（オプション）
 easyocr
+google-cloud-vision


### PR DESCRIPTION
## Summary
- integrate Google Cloud Vision API when `ocr_engine` is set to `saas`
- implement text/box extraction in `ocr_saas_gcp_visionai`
- mention SaaS engine in README
- require `google-cloud-vision` package

## Testing
- `python3 -m py_compile modules/ocr_saas_gcp_visionai.py modules/text_extractor.py`
- `pip install -r requirements.txt` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_6855119bbb248327a668c2f1db13deec