### PR TITLE
Remove config.json fallback in TextExtractor

### DIFF
--- a/main.py
+++ b/main.py
@@ -131,6 +131,8 @@ if __name__ == "__main__":
                         help='Mono color when color_mode is mono. Hex or R,G,B')
     parser.add_argument('--ocr_engine', default='', type=str,
                         help='OCR engine to use (tesseract, easyocr, saas)')
+    parser.add_argument('--gcp_credentials', default='', type=str,
+                        help='Path to Google Cloud credentials JSON')
     parser.add_argument('--single_instance_only', default='false', type=str,
                         help='When true, allow duplicate launches by skipping instance checks')
     # 監視するディレクトリパスは、Pythonプロジェクトフォルダが置かれたディレクトリ（およびそのサブディレクトリ）
@@ -146,7 +148,8 @@ if __name__ == "__main__":
 
     # 設定ファイルの値で上書きし、さらに起動引数があればそちらを優先
     for key in ['exclude_subdirectories', 'ignore_subfolders', 'target', 'seconds', 'ip', 'port', 'delay',
-                'output_dir', 'no_console', 'crop', 'color_mode', 'color', 'ocr_engine', 'single_instance_only']:
+                'output_dir', 'no_console', 'crop', 'color_mode', 'color', 'ocr_engine',
+                'gcp_credentials', 'single_instance_only']:
         if getattr(args, key) == parser.get_default(key) and key in config:
             setattr(args, key, config[key])
 
@@ -155,6 +158,8 @@ if __name__ == "__main__":
 
     if args.ocr_engine == '':
         args.ocr_engine = None
+    if args.gcp_credentials == '':
+        args.gcp_credentials = None
 
     # ignore_subfolders is treated as an alias of exclude_subdirectories
     if args.ignore_subfolders:
@@ -224,7 +229,8 @@ if __name__ == "__main__":
         color_mode=args.color_mode,
         mono_color=args.color,
         enable_udp=use_udp,
-        ocr_engine=args.ocr_engine)
+        ocr_engine=args.ocr_engine,
+        gcp_credentials=args.gcp_credentials)
 
     # サーバーとの通信を試みる
     response = hello_server(path)

--- a/modules/filehandler.py
+++ b/modules/filehandler.py
@@ -19,7 +19,7 @@ class TargetFileHandler(FileSystemEventHandler):
 
     def __init__(self, exclude_subdirectories, seconds, output_dir,
                  crop=False, color_mode="original", mono_color="#000000",
-                 ocr_engine="tesseract"):
+                 ocr_engine="tesseract", gcp_credentials=None):
         super().__init__()
         self.exclude_subdirectories = exclude_subdirectories
         self.seconds = seconds
@@ -28,6 +28,7 @@ class TargetFileHandler(FileSystemEventHandler):
         self.color_mode = color_mode
         self.mono_color = mono_color
         self.ocr_engine = ocr_engine
+        self.gcp_credentials = gcp_credentials
 
     def destroy(self, reason):
         # 終了メッセージをUDPで送信する
@@ -73,7 +74,8 @@ class TargetFileHandler(FileSystemEventHandler):
                 crop=self.crop,
                 color_mode=self.color_mode,
                 mono_color=self.mono_color,
-                ocr_engine=self.ocr_engine
+                ocr_engine=self.ocr_engine,
+                gcp_credentials=self.gcp_credentials
             ).extract_texts(file_path)
             if output_path:
                 print(f'Text extraction succeeded: {output_path}')

--- a/modules/filehandler_communication.py
+++ b/modules/filehandler_communication.py
@@ -20,7 +20,7 @@ class TargetFileHandler(FileSystemEventHandler):
 
     def __init__(self, exclude_subdirectories, sender, ip, port, seconds, output_dir,
                  crop=False, color_mode="original", mono_color="#000000", enable_udp=True,
-                 ocr_engine="tesseract"):
+                 ocr_engine="tesseract", gcp_credentials=None):
         super().__init__()
         self.exclude_subdirectories = exclude_subdirectories
         self.ip = ip
@@ -34,6 +34,7 @@ class TargetFileHandler(FileSystemEventHandler):
         self.color_mode = color_mode
         self.mono_color = mono_color
         self.ocr_engine = ocr_engine
+        self.gcp_credentials = gcp_credentials
 
         # 処理済みファイルを追跡するためのセット
         self.processed_files = set()
@@ -162,7 +163,8 @@ class TargetFileHandler(FileSystemEventHandler):
                 crop=self.crop,
                 color_mode=self.color_mode,
                 mono_color=self.mono_color,
-                ocr_engine=self.ocr_engine
+                ocr_engine=self.ocr_engine,
+                gcp_credentials=self.gcp_credentials
             ).extract_texts(file_path)
             if output_path:
                 print(f'Text extraction succeeded: {output_path}')


### PR DESCRIPTION
## Summary
- stop TextExtractor from reading `config.json`
- allow passing `gcp_credentials` and `ocr_engine` as parameters
- propagate credentials through handlers and CLI

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685526fa29b08327898448a9dc2ef5b5