### PR TITLE
Handle missing potrace

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,7 +41,7 @@
 
     最新の安定版を選択し、インストーラーをダウンロード後、インストーラーを実行し、Tesseractをインストールします。インストール後、Tesseractの実行ファイルがシステムのパスに追加されていることを確認してください。
 
-    注：Tesseractのインストール先は、デフォルトでは `C:\Program Files\Tesseract-OCR` です。インストール後、PATH環境変数に追加する必要があります。
+    注：Tesseractのインストール先は、デフォルトでは `C:\Program Files\Tesseract-OCR` です。インストール後、`PATH` 環境変数に追加するか、環境変数 `TESSERACT_PATH` にフルパスを設定してください。
 
 ## Usage
 
@@ -168,9 +168,11 @@ text_cropping.exe --exclude_subdirectories --ip <IPアドレス> --port <ポー�
    pip install -r requirements.txt
    ```
 
-4. [Tesseract Windows Installer](https://github.com/UB-Mannheim/tesseract/wiki) をインストールします。Tesseract はシステムパスに追加されているか、またはその実行ファイルが直接このスクリプトと同じディレクトリに存在することが前提となっています。
+4. [Tesseract Windows Installer](https://github.com/UB-Mannheim/tesseract/wiki) をインストールします。Tesseract の実行ファイルが `PATH` に含まれていない場合は、環境変数 `TESSERACT_PATH` にフルパスを設定してください。
 
-5. main.py スクリプトを使用して、ディレクトリの監視とサムネイル生成を開始します。
+5. [potrace](http://potrace.sourceforge.net/) をインストールし、実行ファイルへのパスを環境変数 `POTRACE_PATH` または `PATH` に追加します。SVG 出力機能を利用する場合に必須です。
+
+6. main.py スクリプトを使用して、ディレクトリの監視とサムネイル生成を開始します。
 
    ```shell
    python main.py --exclude_subdirectories --target <監視対象ディレクトリ> --seconds 2 --ip <IPアドレス> --port <ポート番号> --delay 3

--- a/modules/text_extractor.py
+++ b/modules/text_extractor.py
@@ -74,13 +74,37 @@ def log_detected_text(text):
     """検出されたテキストを専用ログに記録する"""
     detected_text_logger.log(DETECTED_TEXT, f"検出テキスト: \n{text}")
 
+
+def _resolve_executable(env_var, command, extra_paths=None):
+    """Resolve executable path from env var, system PATH or common locations."""
+    path = os.environ.get(env_var)
+    if path:
+        path = path.strip('"')  # handle quoted paths
+        if os.path.isfile(path):
+            return path
+    found = shutil.which(command)
+    if found:
+        return found
+    if extra_paths:
+        for p in extra_paths:
+            if os.path.isfile(p):
+                return p
+    return None
+
 # 優先順位：
 # 1. 環境変数で TESSERACT_PATH があればそれを使う
 # 2. なければ、PATHから自動検出
 # 3. それも失敗したらエラーを投げる
 
 
-tess_path = os.environ.get("TESSERACT_PATH") or shutil.which("tesseract")
+tess_path = _resolve_executable(
+    "TESSERACT_PATH",
+    "tesseract",
+    [
+        r"C:\\Program Files\\Tesseract-OCR\\tesseract.exe",
+        r"C:\\Program Files (x86)\\Tesseract-OCR\\tesseract.exe",
+    ],
+)
 TESSERACT_AVAILABLE = tess_path is not None
 
 if TESSERACT_AVAILABLE:
@@ -130,19 +154,27 @@ class TextExtractor:
 
     def _save_svg(self, mask, svg_path):
         """Save mask as SVG using potrace."""
+        temp_path = None
         try:
+            potrace_path = _resolve_executable("POTRACE_PATH", "potrace")
+            if not potrace_path:
+                text_logger.error(
+                    "potraceが見つかりません。'POTRACE_PATH'を設定するか、PATHに追加してください")
+                return
             with tempfile.NamedTemporaryFile(delete=False, suffix=".pbm") as tmp:
                 Image.fromarray(mask).convert("1").save(tmp.name)
-            subprocess.run(["potrace", tmp.name, "-s",
-                           "-o", svg_path], check=True)
+                temp_path = tmp.name
+
+            subprocess.run([potrace_path, temp_path, "-s", "-o", svg_path], check=True)
             text_logger.info(f"SVGを保存しました: {svg_path}")
         except Exception as e:
             text_logger.error(f"SVG保存中にエラーが発生しました: {e}")
         finally:
-            try:
-                os.remove(tmp.name)
-            except Exception:
-                pass
+            if temp_path:
+                try:
+                    os.remove(temp_path)
+                except Exception:
+                    pass
 
     def _parse_color(self, color):
         """Convert color specification to BGR tuple."""


### PR DESCRIPTION
## Summary
- improve error handling when generating SVG outlines with potrace
- document potrace installation requirement
- refine tesseract/potrace path resolution

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: externally-managed-environment)*

------
https://chatgpt.com/codex/tasks/task_e_6859323581d8832792d5b34496c1b421