### PR TITLE
Improve file readiness handling

### DIFF
--- a/modules/filehandler_communication.py
+++ b/modules/filehandler_communication.py
@@ -169,6 +169,8 @@ class TargetFileHandler(FileSystemEventHandler):
     def extract_texts(self, file_path):
         """指定された画像から文字部分を抽出します。"""
         try:
+            if not os.path.exists(file_path):
+                raise FileNotFoundError(f"File not found: {file_path}")
             output_path = TextExtractor(
                 self.output_dir,
                 crop=self.crop,


### PR DESCRIPTION
## Summary
- add `wait_for_file_ready` helper to ensure file size is stable before reading
- use helper in `TextExtractor.extract_texts`
- verify file existence before processing in `TargetFileHandler`

## Testing
- `python3 -m py_compile modules/text_extractor.py modules/filehandler_communication.py`
- `python3 -m compileall -q` *(fails: Can't list '/usr/lib/python312.zip')*

------
https://chatgpt.com/codex/tasks/task_e_685bce890a948327a58787b9a31e3314